### PR TITLE
Update node version to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ outputs:
     description: 'Registry Expiry number of days left'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Action uses node12 which is deprecated and will be forced to run on node16